### PR TITLE
Add support for handling Ghost draft posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost2hexo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost2hexo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A converter from ghost exported json file to hexo yaml posts",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -75,9 +75,8 @@ const createPost = (post, dest, authorsMap) => {
   const destFile = post.page
     ? path.join(dest, '..', `${post.slug}.md`)
     : path.join(
-      dest,
-      `${post.published_at.toString().substr(0, 10)}_${post.slug}.md`
-    )
+      dest, 
+      `${post.published_at ? post.published_at.substr(0, 10) : '__draft__'}_${post.slug}.md`)
 
   const content = `---
 uuid:             ${YAML.stringify(post.uuid)}

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const createPost = (post, dest, authorsMap) => {
     ? path.join(dest, '..', `${post.slug}.md`)
     : path.join(
       dest, 
-      `${post.published_at ? post.published_at.substr(0, 10) : '__draft__'}_${post.slug}.md`)
+      `${post.published_at ? post.published_at.substr(0, 10) : '../_drafts/_draft'}_${post.slug}.md`)
 
   const content = `---
 uuid:             ${YAML.stringify(post.uuid)}


### PR DESCRIPTION
Solves #1 

This PR adds a null check on published_at, and if it's null, prefixes the post with "_draft_" and places in the default _drafts folder relative to the user-supplied _posts folder. 

This wouldn't support an edge case (like the user having a different folder for drafts) but does handle the Hexo default scenario which will probably be the most common when migrating from Ghost.

We could probably add support for letting the user specify the location for drafts, but that involves additional checks and input, and is (as mentioned above) likely an edge case.