### PR TITLE
If markdown content (ghost v1) is missing, use html (ghost v2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost2hexo",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost2hexo",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "A converter from ghost exported json file to hexo yaml posts",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ meta_description: ${YAML.stringify(post.meta_description)}
 ${YAML.stringify({ tags: postsTagsMap[post.id] }, 2, 2)}
 ---
 
-${post.markdown}
+${post.markdown ? post.markdown : post.html}
 `
   fs.writeFile(destFile, content, 'utf8', err => {
     if (err) {


### PR DESCRIPTION
Solves #6 

This is a simple fix for supporting Ghost 2.x migrations to Hexo. Not ideal to include html markup in the .md posts, but usable and will render correctly in most cases.

Since Ghost started using mobiledoc format with v2, there's 3 options I found on the exported data json:

- mobiledoc
- html
- plaintext

We could start looking into adding a dependency on an html or mobiledoc to markdown library for full markdown conversion, but that could happen in a follow-up PR, while this will immediately support ghost v2 migration.